### PR TITLE
Remove "TrustedProxy": "10.1.1.10",

### DIFF
--- a/docs/Example configs/haproxy-with-sni-sample.cfg
+++ b/docs/Example configs/haproxy-with-sni-sample.cfg
@@ -3,9 +3,7 @@
 # 
 # Specify the hostname and port that has the public certificate
 # "tlsOffload": "https://mc.publicdomain.com:443",
-# 
-# Specify the IP address of the HAProxy instance (this might not be the address that is bound to the listener).
-# "TrustedProxy": "10.1.1.10",
+
 
 
 frontend sni-front


### PR DESCRIPTION
https://www.reddit.com/r/MeshCentral/comments/wq4nz8/trouble_with_amt/ 

u/ylianst
""tlsOffload" and "trustedProxy" as not compatible settings, use one or the other. If HAProxy is performing TLS and sending unencrypted TCP connections to the MeshCentral, use "tlsOffload". It seems like that's what you want here."