### PR TITLE
HAProxy split trustedProxy into secondary section

### DIFF
--- a/docs/Example configs/haproxy-with-sni-sample.cfg
+++ b/docs/Example configs/haproxy-with-sni-sample.cfg
@@ -1,12 +1,10 @@
 # Uses proxy protocol in HAProxy in combination with SNI to preserve the original host address
 # Update the config.json to work with HAProxy
+# Specify the IP addrehostname that the traffic will come from HAProxy (this might not be the address that is bound to the listener)
+# "tlsOffload": "10.1.1.10",
 # 
-# Specify the hostname and port that has the public certificate
-# "tlsOffload": "https://mc.publicdomain.com:443",
-# 
-# Specify the IP address of the HAProxy instance (this might not be the address that is bound to the listener).
-# "TrustedProxy": "10.1.1.10",
-
+# Specify the HAPRoxy URL with the hostname to get the certificate
+# "certUrl": "https://mc.publicdomain.com:443/"
 
 frontend sni-front
         bind 10.1.1.10:443
@@ -38,3 +36,9 @@ backend mc-back-HTTPS
         option http-server-close
         server mc-01 10.1.1.30:443 check port 443 verify none
 
+# In the event that it is required to have TLS between HAProxy and Meshcentral, 
+# Remove the tls_Offload line and replace with trustedProxy
+# Specify the IP addrehostname that the traffic will come from HAProxy (this might not be the address that is bound to the listener)
+# "trustedProxy": "10.1.1.10",
+# and change the last line of backend mc-back-HTTPS to use HTTPS by adding the ssl keyword
+# server mc-01 10.1.1.30:443 check ssl port 443 verify none


### PR DESCRIPTION
mini explanation on when to use trustedProxy instead of tlsOffload